### PR TITLE
Feature/output handler pretty

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ Following, those are the options exposed when running the test:
       -o OUTPUTS, --outputs=OUTPUTS
                             Output handlers separated by comma. Options: dots,
                             xml, full, remote, tree, excel, db, artifact,
-                            signature, loginfo, logdebug
+                            signature, loginfo, logdebug, pretty
       -f FILTER, --filter=FILTER
                             Run only tests that match the filter expression, e.g
                             "Tag1* and not Tag13"

--- a/docs/cli_options/client_options.rst
+++ b/docs/cli_options/client_options.rst
@@ -32,7 +32,7 @@ First, and most important, using the help options :option:`-h` or
       -o OUTPUTS, --outputs=OUTPUTS
                             Output handlers separated by comma. Options: dots,
                             xml, full, remote, tree, excel, db, artifact,
-                            signature, loginfo, logdebug
+                            signature, loginfo, logdebug, pretty
       -f FILTER, --filter=FILTER
                             Run only tests that match the filter expression, e.g
                             "Tag1* and not Tag13"

--- a/docs/output_handlers.rst
+++ b/docs/output_handlers.rst
@@ -106,6 +106,7 @@ Logs
 ====
 
 To see the logs while running the tests, use ``logdebug`` or ``loginfo``.
+Additionally, you can use ``pretty`` for an easier to read logging system.
 As expected, ``logdebug`` will print every log record with level which is
 higher or equal to ``DEBUG`` (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``,
 ``CRITICAL``), whereas ``loginfo`` will print every log record with level which

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ result_handlers = [
     "artifact = rotest.core.result.handlers.artifact_handler:ArtifactHandler",
     "logdebug = "
     "rotest.core.result.handlers.stream.log_handler:LogDebugHandler",
+    "pretty = "
+    "rotest.core.result.handlers.stream.log_handler:PrettyHandler",
     "signature = "
     "rotest.core.result.handlers.signature_handler:SignatureHandler",
     "full = "

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if not sys.platform.startswith("win32"):
 
 setup(
     name='rotest',
-    version="2.7.6",
+    version="2.7.7",
     description="Resource oriented testing framework",
     long_description=open("README.rst").read(),
     license="MIT",

--- a/src/rotest/core/default_config.json
+++ b/src/rotest/core/default_config.json
@@ -2,7 +2,7 @@
   "save_state": false,
   "delta_iterations": 0,
   "processes": null,
-  "outputs": ["logdebug", "excel"],
+  "outputs": ["pretty", "excel"],
   "filter": null,
   "run_name": null,
   "list": false,

--- a/src/rotest/core/result/handlers/stream/log_handler.py
+++ b/src/rotest/core/result/handlers/stream/log_handler.py
@@ -2,7 +2,7 @@
 import logging
 
 from rotest.common import core_log
-from rotest.core.utils.pretty import wrap_title, Result
+from rotest.core.utils.pretty import Pretty, TestResult
 from stream_handler import EventStreamHandler
 from rotest.common.log import ColoredFormatter
 
@@ -53,7 +53,7 @@ class PrettyHandler(LogStreamHandler):
     LEVEL = logging.DEBUG
 
     def start_test(self, test):
-        self.stream.writeln(wrap_title(test, Result.started))
+        self.stream.writeln(str(Pretty(test, TestResult.started)))
 
     def stop_test(self, test):
         pass
@@ -62,13 +62,13 @@ class PrettyHandler(LogStreamHandler):
         pass
 
     def add_success(self, test):
-        self.stream.writeln(wrap_title(test, Result.success))
+        self.stream.writeln(str(Pretty(test, TestResult.success)))
 
     def add_skip(self, test, reason):
-        self.stream.writeln(wrap_title(test, Result.skip))
+        self.stream.writeln(str(Pretty(test, TestResult.skip)))
 
     def add_error(self, test, exception_str):
-        self.stream.writeln(wrap_title(test, Result.error))
+        self.stream.writeln(str(Pretty(test, TestResult.error)))
 
     def add_failure(self, test, exception_str):
-        self.stream.writeln(wrap_title(test, Result.failure))
+        self.stream.writeln(str(Pretty(test, TestResult.failure)))

--- a/src/rotest/core/result/handlers/stream/log_handler.py
+++ b/src/rotest/core/result/handlers/stream/log_handler.py
@@ -2,7 +2,7 @@
 import logging
 
 from rotest.common import core_log
-from rotest.core.utils.pretty import wrap_title
+from rotest.core.utils.pretty import wrap_title, Result
 from stream_handler import EventStreamHandler
 from rotest.common.log import ColoredFormatter
 
@@ -53,7 +53,7 @@ class PrettyHandler(LogStreamHandler):
     LEVEL = logging.DEBUG
 
     def start_test(self, test):
-        self.stream.writeln(wrap_title(test, 'default'))
+        self.stream.writeln(wrap_title(test, Result.started))
 
     def stop_test(self, test):
         pass
@@ -62,13 +62,13 @@ class PrettyHandler(LogStreamHandler):
         pass
 
     def add_success(self, test):
-        self.stream.writeln(wrap_title(test, 'success'))
+        self.stream.writeln(wrap_title(test, Result.success))
 
     def add_skip(self, test, reason):
-        self.stream.writeln(wrap_title(test, 'skip'))
+        self.stream.writeln(wrap_title(test, Result.skip))
 
     def add_error(self, test, exception_str):
-        self.stream.writeln(wrap_title(test, 'error'))
+        self.stream.writeln(wrap_title(test, Result.error))
 
     def add_failure(self, test, exception_str):
-        self.stream.writeln(wrap_title(test, 'fail'))
+        self.stream.writeln(wrap_title(test, Result.failure))

--- a/src/rotest/core/result/handlers/stream/log_handler.py
+++ b/src/rotest/core/result/handlers/stream/log_handler.py
@@ -2,6 +2,7 @@
 import logging
 
 from rotest.common import core_log
+from rotest.core.utils.pretty import wrap_title
 from stream_handler import EventStreamHandler
 from rotest.common.log import ColoredFormatter
 
@@ -45,3 +46,29 @@ class LogDebugHandler(LogStreamHandler):
     """Debug-level log to screen handler."""
     NAME = 'logdebug'
     LEVEL = logging.DEBUG
+
+
+class PrettyHandler(LogStreamHandler):
+    NAME = 'pretty'
+    LEVEL = logging.DEBUG
+
+    def start_test(self, test):
+        self.stream.writeln(wrap_title(test, 'default'))
+
+    def stop_test(self, test):
+        pass
+
+    def stop_test_run(self):
+        pass
+
+    def add_success(self, test):
+        self.stream.writeln(wrap_title(test, 'success'))
+
+    def add_skip(self, test, reason):
+        self.stream.writeln(wrap_title(test, 'skip'))
+
+    def add_error(self, test, exception_str):
+        self.stream.writeln(wrap_title(test, 'error'))
+
+    def add_failure(self, test, exception_str):
+        self.stream.writeln(wrap_title(test, 'fail'))

--- a/src/rotest/core/result/handlers/stream/log_handler.py
+++ b/src/rotest/core/result/handlers/stream/log_handler.py
@@ -49,17 +49,12 @@ class LogDebugHandler(LogStreamHandler):
 
 
 class PrettyHandler(LogStreamHandler):
+    """Pretty log to screen handler."""
     NAME = 'pretty'
     LEVEL = logging.DEBUG
 
     def start_test(self, test):
         self.stream.writeln(str(Pretty(test, TestResult.started)))
-
-    def stop_test(self, test):
-        pass
-
-    def stop_test_run(self):
-        pass
 
     def add_success(self, test):
         self.stream.writeln(str(Pretty(test, TestResult.success)))
@@ -72,3 +67,9 @@ class PrettyHandler(LogStreamHandler):
 
     def add_failure(self, test, exception_str):
         self.stream.writeln(str(Pretty(test, TestResult.failure)))
+
+    def add_expected_failure(self, test, exception_str):
+        self.stream.writeln(str(Pretty(test, TestResult.expected_failure)))
+
+    def add_unexpected_success(self, test):
+        self.stream.writeln(str(Pretty(test, TestResult.unexpected_success)))

--- a/src/rotest/core/utils/pretty.py
+++ b/src/rotest/core/utils/pretty.py
@@ -1,0 +1,113 @@
+"""Utils module for pretty-printing the logs."""
+import os
+import sys
+import struct
+
+from termcolor import colored
+
+from rotest.core.suite import TestSuite
+from rotest.core.case import TestCase
+from rotest.core.flow import TestFlow
+from rotest.core.block import TestBlock
+
+
+def wrap_title(test, result):
+    columns = get_columns()
+
+    test_class = test.__class__.__name__
+    if isinstance(test, TestBlock):
+        test_type = "Block"
+        title_char = "-"
+        if result == "default":
+            result = "block-default"
+
+    elif isinstance(test, TestFlow):
+        test_type = "Flow"
+        title_char = "="
+        if result == "default":
+            result = "flow-default"
+
+    elif isinstance(test, TestCase):
+        test_type = "Case"
+        title_char = "-"
+        if result == "default":
+            result = "block-default"
+
+    elif isinstance(test, TestSuite):
+        test_type = "Suite"
+        title_char = "="
+        if result == "default":
+            result = "flow-default"
+
+    else:
+        raise TypeError("Unsupported type for pretty-logging: %r" % test_class)
+
+    result_to_type_color = {
+        "fail": "red",
+        "error": "red",
+        "skip": "white",
+        "success": "green",
+        "block-default": "white",
+        "flow-default": "white"
+    }
+
+    result_to_name_color = {
+        "fail": "red",
+        "error": "red",
+        "skip": "yellow",
+        "success": "green",
+        "block-default": "cyan",
+        "flow-default": "blue"
+    }
+
+    name_color = result_to_name_color[result]
+    type_color = result_to_type_color[result]
+
+    if result in ("block-default", "flow-default"):
+        result = "started"
+
+    text_len_without_colors = (len(test_type) + 2 + len(test_class) +
+                               len(result) + 2 + 3)
+    abs_len = (columns - text_len_without_colors)
+    final_text = "{decore}\n{decoration_left} {test_type}: " \
+                 "{test_name} ({result}) {decoration_right}{decore}"
+    formatted = final_text.format(
+        decoration_left=colored(title_char * (abs_len / 2), color=type_color),
+        decoration_right=colored(title_char * ((abs_len if abs_len % 2 == 0
+                                                else abs_len + 1) / 2),
+                                 color=type_color),
+        test_type=colored(test_type, color=type_color, attrs=["bold"]),
+        test_name=colored(test_class, color=name_color),
+        result=colored(result.capitalize(), color=name_color),
+        decore=colored("\n" + (title_char * columns), type_color)
+        if test.IS_COMPLEX else ""
+    )
+
+    return formatted
+
+
+def get_columns():
+    """Return the amount of columns in the current terminal.
+
+    Returns:
+        int. width of a single row in the current terminal.
+    """
+    if sys.platform in ("linux", "linux2", "darwin"):
+        # Both OS X (darwin) and Linux support the 'stty' command
+        _, columns = os.popen("stty size").read().split()
+        columns = int(columns)
+        return columns
+
+    if sys.platform == "win32":
+        from ctypes import windll, create_string_buffer
+        handle = windll.kernel32.GetStdHandle(-12)  # stderr
+        info_buffer = create_string_buffer(22)
+        result = windll.kernel32.GetConsoleScreenBufferInfo(handle,
+                                                            info_buffer)
+        if result:
+            parsed_result = struct.unpack("hhhhHhhhhhh", info_buffer.raw)
+            (_, _, _, _, _, left, top, right, bottom, _, _) = parsed_result
+            return right - left + 1
+
+    # Return default terminal width
+    return 80

--- a/src/rotest/core/utils/pretty.py
+++ b/src/rotest/core/utils/pretty.py
@@ -10,6 +10,21 @@ from rotest.core.case import TestCase
 from rotest.core.flow import TestFlow
 from rotest.core.block import TestBlock
 
+import enum
+
+
+class Result(enum.Enum):
+    success = "success"
+    skip = "skip"
+    error = "error"
+    failure = "fail"
+    started = "started"
+    block_started = "block-started"
+    flow_started = "flow-started"
+
+    def __str__(self):
+        return str(self.value)
+
 
 def wrap_title(test, result):
     columns = get_columns()
@@ -18,53 +33,55 @@ def wrap_title(test, result):
     if isinstance(test, TestBlock):
         test_type = "Block"
         title_char = "-"
-        if result == "default":
-            result = "block-default"
+        if result == Result.started:
+            result = Result.block_started
 
     elif isinstance(test, TestFlow):
         test_type = "Flow"
         title_char = "="
-        if result == "default":
-            result = "flow-default"
+        if result == Result.started:
+            result = Result.flow_started
 
     elif isinstance(test, TestCase):
         test_type = "Case"
         title_char = "-"
-        if result == "default":
-            result = "block-default"
+        if result == Result.started:
+            result = Result.block_started
 
     elif isinstance(test, TestSuite):
         test_type = "Suite"
         title_char = "="
-        if result == "default":
-            result = "flow-default"
+        if result == Result.started:
+            result = Result.flow_started
 
     else:
         raise TypeError("Unsupported type for pretty-logging: %r" % test_class)
 
     result_to_type_color = {
-        "fail": "red",
-        "error": "red",
-        "skip": "white",
-        "success": "green",
-        "block-default": "white",
-        "flow-default": "white"
+        Result.failure: "red",
+        Result.error: "red",
+        Result.skip: "white",
+        Result.success: "green",
+        Result.block_started: "white",
+        Result.flow_started: "white"
     }
 
     result_to_name_color = {
-        "fail": "red",
-        "error": "red",
-        "skip": "yellow",
-        "success": "green",
-        "block-default": "cyan",
-        "flow-default": "blue"
+        Result.failure: "red",
+        Result.error: "red",
+        Result.skip: "yellow",
+        Result.success: "green",
+        Result.block_started: "cyan",
+        Result.flow_started: "blue"
     }
 
     name_color = result_to_name_color[result]
     type_color = result_to_type_color[result]
 
-    if result in ("block-default", "flow-default"):
-        result = "started"
+    if result in (Result.block_started, Result.flow_started):
+        result = Result.started
+
+    result = str(result)
 
     text_len_without_colors = (len(test_type) + 2 + len(test_class) +
                                len(result) + 2 + 3)

--- a/src/rotest/core/utils/pretty.py
+++ b/src/rotest/core/utils/pretty.py
@@ -29,15 +29,7 @@ class TitleConfiguration(object):
         self.result = result
 
     has_multi_line_decoration = False
-
-    @abstractproperty
-    def decoration_character(self):
-        """Define the character that will be used to decorate the test.
-
-        Returns:
-            str. character to be printed in the log.
-        """
-        pass
+    decoration_character = "-"
 
     @abstractproperty
     def decoration_color(self):
@@ -93,10 +85,6 @@ class TitleConfiguration(object):
 
 class NonComplexTitleConfiguration(TitleConfiguration):
     """Title configuration for tests that are not complex."""
-    @property
-    def decoration_character(self):
-        return "-"
-
     @property
     def decoration_color(self):
         colors = {
@@ -156,10 +144,7 @@ class NonComplexTitleConfiguration(TitleConfiguration):
 class ComplexTitleConfiguration(TitleConfiguration):
     """Title configuration for complex tests."""
     has_multi_line_decoration = True
-
-    @property
-    def decoration_character(self):
-        return "="
+    decoration_character = "="
 
     @property
     def decoration_color(self):
@@ -330,8 +315,9 @@ class Pretty(object):
 
     def _whole_decoration_line_width(self):
         """Return the width of the whole decoration line.
-               That means the left and right decoration combined.
-               To be used for calculating the left and right decorations.
+
+       That means the left and right decoration combined, to be used for
+       calculating the left and right decorations.
 
             Returns:
                 int. width of the whole decoration line together.

--- a/src/rotest/core/utils/pretty.py
+++ b/src/rotest/core/utils/pretty.py
@@ -28,6 +28,8 @@ class TitleConfiguration(object):
     def __init__(self, result):
         self.result = result
 
+    has_multi_line_decoration = False
+
     @abstractproperty
     def decoration_character(self):
         """Define the character that will be used to decorate the test.
@@ -65,15 +67,6 @@ class TitleConfiguration(object):
         pass
 
     @abstractproperty
-    def has_multi_line_decoration(self):
-        """Determine whether or not this test has a multi-line decoration.
-
-        Returns:
-            bool. True if this tests has multiple lines of decoration.
-        """
-        pass
-
-    @abstractproperty
     def test_result_color(self):
         """Define the color of the test's result.
 
@@ -100,11 +93,6 @@ class TitleConfiguration(object):
 
 class NonComplexTitleConfiguration(TitleConfiguration):
     """Title configuration for tests that are not complex."""
-
-    @property
-    def has_multi_line_decoration(self):
-        return False
-
     @property
     def decoration_character(self):
         return "-"
@@ -167,10 +155,7 @@ class NonComplexTitleConfiguration(TitleConfiguration):
 
 class ComplexTitleConfiguration(TitleConfiguration):
     """Title configuration for complex tests."""
-
-    @property
-    def has_multi_line_decoration(self):
-        return True
+    has_multi_line_decoration = True
 
     @property
     def decoration_character(self):
@@ -252,10 +237,11 @@ class Pretty(object):
     """Title with decoration.
 
     Attributes:
-        test (AbstractTest): encapsulated test to generate it's title.
+        test (AbstractTest): encapsulated test to generate its title.
         result (TestResult): result that the tests ended with (or didn't end).
         configuration (TitleConfiguration): title's configuration of colors.
     """
+
     def __init__(self, test, result):
         self.test = test
         self.result = result
@@ -344,8 +330,8 @@ class Pretty(object):
 
     def _whole_decoration_line_width(self):
         """Return the width of the whole decoration line.
-            That means the left and right decoration combined.
-            To be used for calculating the left and right decorations.
+               That means the left and right decoration combined.
+               To be used for calculating the left and right decorations.
 
             Returns:
                 int. width of the whole decoration line together.


### PR DESCRIPTION
Added an (on-by-default) output handler called "pretty". 
It decorates the beginning and ending of tests, creating an easy-to-identify patterns in the log.