### PR TITLE
Disable discovering tests not on their modules

### DIFF
--- a/src/rotest/cli/discover.py
+++ b/src/rotest/cli/discover.py
@@ -79,9 +79,10 @@ def discover_tests_under_paths(paths):
 
         module = py.path.local(path).pyimport()
         tests_discovered = loader.loadTestsFromModule(module)
-        tests_discovered = [test
-                            for test in tests_discovered
-                            if is_test_class(test)]
+        tests_discovered = [
+            test
+            for test in tests_discovered
+            if is_test_class(test) and test.__module__ == module.__name__]
 
         core_log.debug("Discovered %d tests in %s",
                        len(tests_discovered), path)

--- a/src/rotest/core/flow_component.py
+++ b/src/rotest/core/flow_component.py
@@ -138,7 +138,11 @@ class AbstractFlowComponent(AbstractTest):
         """
         new_common = cls.common.copy()
         new_common.update(**parameters)
-        return type(cls.__name__, (cls,), {'common': new_common})
+        return type(parameters.get("__name__") or cls.__name__,
+                    (cls,),
+                    dict(common=new_common,
+                         __doc__=cls.__doc__,
+                         __module__=cls.__module__))
 
     # Shortcut
     params = parametrize

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -71,16 +71,35 @@ def test_skipping_files_by_blacklist():
 @mock.patch("rotest.cli.discover.get_test_files",
             mock.MagicMock(return_value=["some_test.py"]))
 @mock.patch("unittest.TestLoader")
-@mock.patch("py.path", mock.MagicMock())
+@mock.patch("py.path.local.pyimport",
+            mock.MagicMock(return_value=mock.MagicMock(__name__="the_module")))
 def test_discovering_tests(loader_mock):
     class Case(TestCase):
         def test(self):
             pass
 
+    Case.__module__ = "the_module"
     loader_mock.return_value.loadTestsFromModule.return_value = [Case]
 
     with mock.patch("__builtin__.__import__"):
         assert discover_tests_under_paths(["some_test.py"]) == {Case}
+
+
+@mock.patch("rotest.cli.discover.get_test_files",
+            mock.MagicMock(return_value=["some_test.py"]))
+@mock.patch("unittest.TestLoader")
+@mock.patch("py.path.local.pyimport",
+            mock.MagicMock(return_value=mock.MagicMock(__name__="the_module")))
+def test_not_discovering_tests_on_other_module(loader_mock):
+    class Case(TestCase):
+        def test(self):
+            pass
+
+    Case.__module__ = "other_module"
+    loader_mock.return_value.loadTestsFromModule.return_value = [Case]
+
+    with mock.patch("__builtin__.__import__"):
+        assert discover_tests_under_paths(["some_test.py"]) == {}
 
 
 def test_importing_bad_file():


### PR DESCRIPTION
* The discover module now discards them
* Added positive and negative tests
* Flow.params now creates classes the right way