### PR TITLE
Make logger cachedproperty

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 
-__version__ = "7.2.0"
+__version__ = "7.2.1"
 
 result_handlers = [
     "db = rotest.core.result.handlers.db_handler:DBHandler",
@@ -47,6 +47,7 @@ setup(
         'basicstruct',
         'future',
         'swaggapi>=0.6.5',
+        'cached_property',
     ],
     extras_require={
         "dev": [

--- a/src/rotest/core/abstract_test.py
+++ b/src/rotest/core/abstract_test.py
@@ -82,7 +82,6 @@ class AbstractTest(unittest.TestCase):
         super(AbstractTest, self).__init__(methodName)
 
         self.result = None
-        self.logger = None
         self.is_main = True
         self.config = config
         self.parent = parent

--- a/src/rotest/core/abstract_test.py
+++ b/src/rotest/core/abstract_test.py
@@ -16,6 +16,7 @@ from itertools import count
 
 from ipdbugger import debug
 from attrdict import AttrDict
+from cached_property import cached_property
 from future.builtins import next, str, object
 from future.utils import iteritems, itervalues
 
@@ -250,10 +251,10 @@ class AbstractTest(unittest.TestCase):
 
         return self.parent.parents_count + 1
 
-    def create_logger(self):
+    @cached_property
+    def logger(self):
         """Create logger instance for the test."""
-        if self.logger is None:
-            self.logger = get_test_logger(get_tree_path(self), self.work_dir)
+        return get_test_logger(get_tree_path(self), self.work_dir)
 
     def start(self):
         """Update the data that the test started."""

--- a/src/rotest/core/case.py
+++ b/src/rotest/core/case.py
@@ -158,7 +158,6 @@ class TestCase(AbstractTest):
         # method signature, but the Rotest test case does not support it.
         self.assertIsNotNone(result, 'TestCase must run inside a TestSuite')
         self.result = result
-        self.create_logger()
 
         # === Decorate the setUp, test and tearDown methods. ===
         setup_method = getattr(self, self.SETUP_METHOD_NAME)

--- a/src/rotest/core/flow.py
+++ b/src/rotest/core/flow.py
@@ -136,12 +136,6 @@ class TestFlow(AbstractFlowComponent):
     def addTest(self, test_item):
         self._tests.append(test_item)
 
-    def create_logger(self):
-        """Create logger instances for the test and its components."""
-        super(TestFlow, self).create_logger()
-        for block in self._tests:
-            block.create_logger()
-
     def validate_inputs(self, extra_inputs=[]):
         """Validate that all the required inputs of the blocks were passed.
 

--- a/src/rotest/core/flow_component.py
+++ b/src/rotest/core/flow_component.py
@@ -328,7 +328,6 @@ class AbstractFlowComponent(AbstractTest):
             result (rotest.core.result.result.Result): test result information.
         """
         self.result = result
-        self.create_logger()
 
         # === Decorate the setUp and tearDown methods ===
         setup_method = getattr(self, self.SETUP_METHOD_NAME)

--- a/src/rotest/core/runners/multiprocess/manager/message_handler.py
+++ b/src/rotest/core/runners/multiprocess/manager/message_handler.py
@@ -179,8 +179,6 @@ class RunnerMessageHandler(object):
             message (StartTest): worker message object.
         """
         # Since the logger is only created in the worker, we create it here
-        test.create_logger()
-
         self.result.startTest(test)
         if test.is_main:
             self.runner.update_worker(worker_pid=message.msg_id, test=test)

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -125,6 +125,29 @@ class TestTestFlow(BasicRotestUnitTest):
         self.assertEqual(test_flow.data.exception_type, TestOutcome.SUCCESS,
                          'Flow data status should have been success')
 
+    def test_giant_flow(self):
+        """See that a flow with a large amount of blocks and doesn't crash."""
+        blocks_num = 1500
+        MockFlow.blocks = [SuccessBlock] * blocks_num
+
+        test_flow = MockFlow()
+        self.run_test(test_flow)
+
+        self.assertTrue(self.result.wasSuccessful(),
+                        'Flow failed when it should have succeeded')
+
+        self.assertEqual(self.result.testsRun, 1,
+                         "Flow didn't run the correct number of blocks")
+
+        self.validate_blocks(test_flow, successes=blocks_num)
+
+        # === Validate data object ===
+        self.assertTrue(test_flow.data.success,
+                        'Flow data result should have been True')
+
+        self.assertEqual(test_flow.data.exception_type, TestOutcome.SUCCESS,
+                         'Flow data status should have been success')
+
     def test_skip_alone(self):
         """Create test flow with only skipped blocks and test its behavior."""
         MockFlow.blocks = (SkipBlock, SkipBlock)

--- a/tests/core/test_suite.py
+++ b/tests/core/test_suite.py
@@ -54,6 +54,28 @@ class TestTestSuite(BasicRotestUnitTest):
                           len(MockTestSuite.components),
                           'Data members number differs form number of tests')
 
+    def test_giant_suite(self):
+        """See that a test suite with a large amount of tests doesn't crash."""
+        tests_amount = 1500
+        MockTestSuite.components = [SuccessCase] * tests_amount
+
+        test_suite = MockTestSuite()
+        self.run_test(test_suite)
+
+        self.assertTrue(self.result.wasSuccessful(),
+                        'Suite failed when it should have succeeded')
+
+        self.assertEqual(self.result.testsRun, tests_amount,
+                         "Suite didn't run the correct number of tests")
+
+        # === Validate data object ===
+        self.assertTrue(test_suite.data.success,
+                        'Suite data result should have been True')
+
+        self.assertEqual(len(list(test_suite)),
+                         len(MockTestSuite.components),
+                         'Data members number differs form number of tests')
+
     def test_skip_init(self):
         """Create a suite that should skip initialization and validate it."""
         MockSuite1.components = (SuccessCase, SuccessCase)


### PR DESCRIPTION
It fixes an error that occures when having a flow with too many blocks (more than max num of file descriptors)