### PR TITLE
Propagate data pointers when declaring sub resources

### DIFF
--- a/docs/advanced/complex_resources.rst
+++ b/docs/advanced/complex_resources.rst
@@ -130,7 +130,32 @@ Note the following:
   .. code-block:: python
 
     sub_process = SubProcess.request(ip_address=CalculatorData.ip_address,
-                                     process_id=5)
+                                     process_id=CalculatorData.sub_process.process_id)
+
+  Alternatively, you can also use rotest.management.DataPointer to point to data
+  fields. This can be used to pass data from one service to its child:
+
+  .. code-block:: python
+
+    from rotest.management import BaseResource, DataPointer
+
+    class SubProcess(BaseResource):
+
+        DATA_CLASS = None
+
+        def __init__(self, process_id, *args, **kwargs):
+            super(SubProcess, self).__init__(*args, process_id=process_id, **kwargs)
+
+
+    class Calculator(BaseResource):
+
+        DATA_CLASS = None
+
+        sub_process = SubProcess.request(process_id=DataPointer("process_id"))
+
+        def __init__(self, process_id, *args, **kwargs):
+            super(Calculator, self).__init__(*args, process_id=process_id, **kwargs)
+
 
 * The usage of the sub-resource
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 
-__version__ = "8.0.4"
+__version__ = "8.1.0"
 
 result_handlers = [
     "db = rotest.core.result.handlers.db_handler:DBHandler",

--- a/src/rotest/management/__init__.py
+++ b/src/rotest/management/__init__.py
@@ -8,6 +8,7 @@ class ManagementConfig(AppConfig):
 
     def ready(self):
         from .models import ResourceData
+        from .models.resource_data import DataPointer
         from .client.manager import ClientResourceManager
         from .base_resource import BaseResource, ResourceRequest
 
@@ -16,6 +17,7 @@ class ManagementConfig(AppConfig):
         rotest.management.ClientResourceManager = ClientResourceManager
         rotest.management.BaseResource = BaseResource
         rotest.management.ResourceRequest = ResourceRequest
+        rotest.management.DataPointer = DataPointer
 
 
 default_app_config = "rotest.management.ManagementConfig"

--- a/src/rotest/management/base_resource.py
+++ b/src/rotest/management/base_resource.py
@@ -16,7 +16,6 @@ from ipdbugger import debug
 from attrdict import AttrDict
 from future.utils import iteritems
 from future.builtins import zip, object
-from django.db.models.query_utils import DeferredAttribute
 
 from rotest.common import core_log
 from rotest.common.config import ROTEST_WORK_DIR

--- a/src/rotest/management/base_resource.py
+++ b/src/rotest/management/base_resource.py
@@ -22,16 +22,8 @@ from rotest.common import core_log
 from rotest.common.config import ROTEST_WORK_DIR
 from rotest.common.utils import parse_config_file
 from rotest.common.utils import get_work_dir, get_class_fields
-from rotest.management.models.resource_data import ResourceData
 from rotest.common.constants import default_config, DEFAULT_SCHEMA_PATH
-
-try:
-    from django.db.models.fields.related_descriptors import \
-        ForwardManyToOneDescriptor
-
-except ImportError:
-    from django.db.models.fields.related import \
-        ReverseSingleRelatedObjectDescriptor as ForwardManyToOneDescriptor
+from rotest.management.models.resource_data import ResourceData, DataPointer
 
 
 class ResourceRequest(object):
@@ -171,11 +163,8 @@ class BaseResource(object):
             actual_kwargs['config'] = self.config
             actual_kwargs['base_work_dir'] = self.work_dir
             for key, value in six.iteritems(sub_request.kwargs):
-                if isinstance(value, ForwardManyToOneDescriptor):
-                    actual_kwargs[key] = getattr(self.data, value.field.name)
-
-                elif isinstance(value, DeferredAttribute):
-                    actual_kwargs[key] = getattr(self.data, value.field_name)
+                if isinstance(value, DataPointer):
+                    actual_kwargs[key] = value.unwrap_data_pointer(self.data)
 
             sub_resource = sub_class(**actual_kwargs)
 

--- a/src/rotest/management/models/resource_data.py
+++ b/src/rotest/management/models/resource_data.py
@@ -81,13 +81,17 @@ class DataBase(ModelBase):
     """
     def __getattribute__(cls, key):
         if int(DJANGO_VERSION[0]) == 1 and int(DJANGO_VERSION[1]) < 10:
-            if '_meta' in vars(cls) and \
-                    key in (field.name for field in cls._meta.fields):
+            try:
+                field_pointer = super(DataBase, cls).__getattribute__(key)
 
-                field_pointer = DeferredAttribute(key, None)
+            except AttributeError:
+                if '_meta' in vars(cls) and \
+                        key in (field.name for field in cls._meta.fields):
 
-            else:
-                raise AttributeError(key)
+                    field_pointer = DeferredAttribute(key, None)
+
+                else:
+                    raise
 
         else:
             field_pointer = super(DataBase, cls).__getattribute__(key)

--- a/src/rotest/management/models/resource_data.py
+++ b/src/rotest/management/models/resource_data.py
@@ -19,10 +19,48 @@ from django import VERSION as DJANGO_VERSION
 from django.contrib.auth import models as auth_models
 from django.db.models.query_utils import DeferredAttribute
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+try:
+    from django.db.models.fields.related_descriptors import \
+        ForwardManyToOneDescriptor
+
+except ImportError:
+    from django.db.models.fields.related import \
+        ReverseSingleRelatedObjectDescriptor as ForwardManyToOneDescriptor
 
 from rotest.common.django_utils.fields import NameField
 from rotest.common.django_utils.common import get_fields
 from rotest.common.django_utils import get_sub_model, linked_unicode
+
+
+class DataPointer(object):
+    def __init__(self, field_pointer, parent_pointer=None):
+        self.field_pointer = field_pointer
+        self.parent_pointer = parent_pointer
+
+    def __getattr__(self, key):
+        try:
+            return getattr(self.field_pointer, key)
+
+        except AttributeError:
+            if hasattr(self.field_pointer, "field"):
+                sub_pointer = getattr(self.field_pointer.field.related_model,
+                                      key)
+
+                if isinstance(sub_pointer, DataPointer):
+                    sub_pointer.parent_pointer = self
+
+                return sub_pointer
+
+            raise
+
+    def unwrap_data_pointer(self, instance):
+        if self.parent_pointer:
+            instance = self.parent_pointer.unwrap_data_pointer(instance)
+
+        if hasattr(self.field_pointer, "field"):
+            return getattr(instance, self.field_pointer.field.name)
+
+        return getattr(instance, self.field_pointer.field_name)
 
 
 class DataBase(ModelBase):
@@ -34,14 +72,26 @@ class DataBase(ModelBase):
             DATA_CLASS = DemoResourceData
             demo1 = DemoService.request(name=DemoResourceData.name).
     """
-    if int(DJANGO_VERSION[0]) == 1 and int(DJANGO_VERSION[1]) < 10:
-        def __getattr__(cls, key):
+    def __getattribute__(cls, key):
+        if int(DJANGO_VERSION[0]) == 1 and int(DJANGO_VERSION[1]) < 10:
             if '_meta' in vars(cls) and \
                     key in (field.name for field in cls._meta.fields):
 
-                return DeferredAttribute(key, None)
+                field_pointer = DeferredAttribute(key, None)
 
-            raise AttributeError(key)
+            else:
+                raise AttributeError(key)
+
+        else:
+            field_pointer = super(DataBase, cls).__getattribute__(key)
+
+        if field_pointer is not None and \
+                isinstance(field_pointer, (DeferredAttribute,
+                                           ForwardManyToOneDescriptor)):
+
+            return DataPointer(field_pointer)
+
+        return field_pointer
 
 
 class ResourceData(six.with_metaclass(DataBase, models.Model)):

--- a/tests/management/test_resource_manager.py
+++ b/tests/management/test_resource_manager.py
@@ -1521,7 +1521,7 @@ class TestResourceManagement(BaseResourceManagementTest):
                 self.data.initialization_flag = True
                 self.data.save()
 
-        resources = DemoResourceData.objects.filter(name=self.FREE1_NAME)
+        resources = DemoResourceData.objects.filter(name=self.COMPLEX_NAME)
 
         resources_num = len(resources)
         self.assertEqual(resources_num, 1, "Expected 1 complex "

--- a/tests/management/test_resource_manager.py
+++ b/tests/management/test_resource_manager.py
@@ -1518,10 +1518,12 @@ class TestResourceManagement(BaseResourceManagementTest):
                 """Turns on the initialization flag."""
                 super(AlterDemoComplexResource, self).initialize()
                 self.data.initialization_flag = True
+                self.data.demo1.save()
+                self.data.demo2.save()
                 self.data.save()
 
         resources = DemoComplexResourceData.objects.filter(
-                                                        name=self.COMPLEX_NAME)
+                                                       name=self.COMPLEX_NAME)
 
         resources_num = len(resources)
         self.assertEqual(resources_num, 1, "Expected 1 complex "

--- a/tests/management/test_resource_manager.py
+++ b/tests/management/test_resource_manager.py
@@ -16,13 +16,12 @@ from waiting import wait
 from future.builtins import zip, range
 from django.db.models.query_utils import Q
 from django.contrib.auth.models import User
-from django.db.models.query_utils import DeferredAttribute
 from swaggapi.api.builder.client import requester
 
 from rotest.management.common.utils import LOCALHOST
-from rotest.management import BaseResource, ResourceRequest
 from rotest.management.client.manager import ClientResourceManager
 from rotest.management.client.websocket_client import PingingWebsocket
+from rotest.management import BaseResource, ResourceRequest, DataPointer
 from rotest.management.common.resource_descriptor import \
                                             ResourceDescriptor as Descriptor
 from rotest.management.models.ut_models import (DemoResourceData,
@@ -1526,15 +1525,15 @@ class TestResourceManagement(BaseResourceManagementTest):
         resources_num = len(resources)
         self.assertEqual(resources_num, 1, "Expected 1 complex "
                          "resource with name %r in DB, found %d"
-                         % (self.FREE1_NAME, resources_num))
+                         % (self.COMPLEX_NAME, resources_num))
 
         resource, = resources
         self.assertTrue(resource.is_available(), "Expected available "
                         "complex resource with name %r in DB, found %d"
-                        % (self.FREE1_NAME, resources_num))
+                        % (self.COMPLEX_NAME, resources_num))
 
         request = ResourceRequest('res1', AlterDemoComplexResource,
-                                  name=self.FREE1_NAME)
+                                  name=self.COMPLEX_NAME)
 
         resources = self.client.request_resources(requests=[request])
 
@@ -1601,7 +1600,7 @@ class TestResourceManagement(BaseResourceManagementTest):
             """Fake complex service class, used in resource manager tests."""
             DATA_CLASS = None
             demo1 = DemoService.request()
-            demo2 = DemoService.request(name=DeferredAttribute('name', None))
+            demo2 = DemoService.request(name=DataPointer('name'))
 
             initialized = False
 

--- a/tests/management/test_resource_manager.py
+++ b/tests/management/test_resource_manager.py
@@ -1520,7 +1520,8 @@ class TestResourceManagement(BaseResourceManagementTest):
                 self.data.initialization_flag = True
                 self.data.save()
 
-        resources = DemoResourceData.objects.filter(name=self.COMPLEX_NAME)
+        resources = DemoComplexResourceData.objects.filter(
+                                                        name=self.COMPLEX_NAME)
 
         resources_num = len(resources)
         self.assertEqual(resources_num, 1, "Expected 1 complex "
@@ -1584,7 +1585,7 @@ class TestResourceManagement(BaseResourceManagementTest):
         self.client.release_resources(list(resources.values()), dirty=True)
 
     def test_lock_alternative_complex_service(self):
-        """Lock complex service with the default 'create_sub_resources'.
+        """Lock passing data using the DataPointer class.
 
         * Validates the DB initial state.
         * Requests an existing complex resource, using resource client.

--- a/tests/management/test_resource_manager.py
+++ b/tests/management/test_resource_manager.py
@@ -1316,7 +1316,7 @@ class TestResourceManagement(BaseResourceManagementTest):
             self.client.request_resources(requests)
 
     def test_lock_alternative_complex_resource(self):
-        """Lock complex resource with the default 'create_sub_resources'.
+        """Validate passing data to sub-resources from the current works.
 
         * Validates the DB initial state.
         * Requests an existing complex resource, using resource client.
@@ -1410,7 +1410,7 @@ class TestResourceManagement(BaseResourceManagementTest):
         self.client.release_resources(list(resources.values()), dirty=True)
 
     def test_lock_alternative_complex_resource_with_service(self):
-        """Lock complex resource with the default 'create_sub_resources'.
+        """Validate passing data to sub-services from the current works.
 
         * Validates the DB initial state.
         * Requests an existing complex resource, using resource client.
@@ -1493,6 +1493,94 @@ class TestResourceManagement(BaseResourceManagementTest):
         self.assertEqual(resources_num, 1, "Expected 1 locked "
                          "resource with name %r in DB, found %d"
                          % (self.FREE1_NAME, resources_num))
+
+        self.client.release_resources(list(resources.values()), dirty=True)
+
+    def test_data_pointer_propagation(self):
+        """Validate passing data from a sub-resource works.
+
+        * Validates the DB initial state.
+        * Requests an existing complex resource, using resource client.
+        * Validates that 1 resource returned.
+        * Validates the name of the returned resource.
+        * Validates the type of the returned resource.
+        * Validates the amount of sub-resources it has.
+        * Validates the resource and its subs were locked and initialized.
+        * Releases the locked resource, using resource client.
+        * Validates the above resource and it sub-resources are now available.
+        """
+        class AlterDemoComplexResource(BaseResource):
+            """Fake complex resource class, used in resource manager tests."""
+            DATA_CLASS = DemoComplexResourceData
+            service = DemoService.request(
+                                    name=DemoComplexResourceData.demo1.name)
+
+            def initialize(self):
+                """Turns on the initialization flag."""
+                super(AlterDemoComplexResource, self).initialize()
+                self.data.initialization_flag = True
+                self.data.save()
+
+        resources = DemoResourceData.objects.filter(name=self.FREE1_NAME)
+
+        resources_num = len(resources)
+        self.assertEqual(resources_num, 1, "Expected 1 complex "
+                         "resource with name %r in DB, found %d"
+                         % (self.FREE1_NAME, resources_num))
+
+        resource, = resources
+        self.assertTrue(resource.is_available(), "Expected available "
+                        "complex resource with name %r in DB, found %d"
+                        % (self.FREE1_NAME, resources_num))
+
+        request = ResourceRequest('res1', AlterDemoComplexResource,
+                                  name=self.FREE1_NAME)
+
+        resources = self.client.request_resources(requests=[request])
+
+        resources_num = len(resources)
+        self.assertEqual(resources_num, 1, "Expected list with 1 "
+                         "resource in it but found %d" % resources_num)
+
+        resource, = resources.values()
+        self.assertEqual(resource.name, self.COMPLEX_NAME,
+                         "Expected resource with name %r but got %r"
+                         % (self.COMPLEX_NAME, resource.name))
+
+        self.assertIsInstance(resource, request.type,
+                              "Expected resource of type %r, but got %r"
+                              % (request.type.__name__,
+                                 resource.__class__.__name__))
+
+        self.assertEqual(len(list(resource.get_sub_resources())), 1,
+                         "Expected to have 1 sub-resources, found %r"
+                         % resource.get_sub_resources())
+
+        self.assertEqual(resource.demo1.name, resource.service.name,
+                         "Expected sub-service with name %r but got %r"
+                         % (resource.name, resource.service.name))
+
+        self.assertTrue(resource.data.initialization_flag,
+                        "Resource %r should have been initialized" %
+                        resource.name)
+
+        for sub_resource in resource.get_sub_resources():
+            self.assertFalse(sub_resource in AlterDemoComplexResource.__dict__,
+                             "Sub-resource %r is still a placeholder" %
+                             sub_resource.name)
+
+            self.assertIsInstance(sub_resource, DemoService,
+                                  "Expected sub-resource of type %r, got %r"
+                                  % (DemoResource.__name__,
+                                     sub_resource.__class__.__name__))
+
+        resources_data = request.type.DATA_CLASS.objects.filter(~Q(owner=""),
+                                                   name=self.COMPLEX_NAME)
+
+        resources_num = len(resources_data)
+        self.assertEqual(resources_num, 1, "Expected 1 locked "
+                         "resource with name %r in DB, found %d"
+                         % (self.COMPLEX_NAME, resources_num))
 
         self.client.release_resources(list(resources.values()), dirty=True)
 


### PR DESCRIPTION
enable doing
ComplexResource(BaseResource):
    DATA_CLASS = SomeComplexData
    subresource = SubResource.request(ip_address=SomeComplexData.sub_data.ip_address)